### PR TITLE
fix: use SensorDeviceClass.APPARENT_POWER for teleinfo instant sensor

### DIFF
--- a/custom_components/ecodevices/sensor.py
+++ b/custom_components/ecodevices/sensor.py
@@ -94,7 +94,7 @@ async def async_setup_entry(
                     input_name=f"T{ti_input_number}",
                     name=default_name,
                     unit=UnitOfApparentPower.VOLT_AMPERE,
-                    device_class=SensorDeviceClass.POWER,
+                    device_class=SensorDeviceClass.APPARENT_POWER,
                     state_class=SensorStateClass.MEASUREMENT,
                     icon="mdi:flash",
                 )


### PR DESCRIPTION
Use SensorDeviceClass.APPARENT_POWER for apparent power
See https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes

Fix for #63 